### PR TITLE
Support `TypeAnnotation` in `JSCodegen`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
     ),
     .target(
       name: "JSCodegen",
-      dependencies: ["Basic", "Syntax"]
+      dependencies: ["Basic", "Syntax", "TypeChecker"]
     ),
     .target(
       name: "Driver",

--- a/Sources/JSCodegen/JSCodegen.swift
+++ b/Sources/JSCodegen/JSCodegen.swift
@@ -4,12 +4,13 @@
 
 import Basic
 import Syntax
+import TypeChecker
 
 extension Bool {
   var not: Bool { !self }
 }
 
-public let jsModuleFileCodegen = CompilerPass<ModuleFile<EmptyAnnotation>, String> {
+public let jsModuleFileCodegen = CompilerPass<ModuleFile<TypeAnnotation>, String> {
   $0.declarations.map(\.jsCodegen).filter(\.isEmpty.not)
     .joined(separator: "\n")
 }

--- a/Sources/Syntax/Declarations/DeclBlock.swift
+++ b/Sources/Syntax/Declarations/DeclBlock.swift
@@ -9,7 +9,7 @@ public struct DeclBlock<A: Annotation> {
   public let elements: [SyntaxNode<Declaration<A>>]
   public let closeBrace: SyntaxNode<Empty>
 
-  func addAnnotation<NewAnnotation: Annotation>(
+  public func addAnnotation<NewAnnotation: Annotation>(
     _ transform: (Declaration<A>) throws -> Declaration<NewAnnotation>
   ) rethrows -> DeclBlock<NewAnnotation> {
     try .init(

--- a/Sources/Syntax/Declarations/FuncDecl.swift
+++ b/Sources/Syntax/Declarations/FuncDecl.swift
@@ -10,6 +10,17 @@ public struct FuncDecl<A: Annotation>: ModifiersContainer {
     public let internalName: SyntaxNode<Identifier>
     public let colon: SyntaxNode<Empty>
     public let type: SyntaxNode<Expr<A>>
+
+    public func addAnnotation<NewAnnotation: Annotation>(
+      _ transform: (Expr<A>) throws -> Expr<NewAnnotation>
+    ) rethrows -> FuncDecl<NewAnnotation>.Parameter {
+      try .init(
+        externalName: externalName,
+        internalName: internalName,
+        colon: colon,
+        type: type.map { try transform($0) }
+      )
+    }
   }
 
   public struct Arrow: SyntaxNodeContainer {

--- a/Sources/Syntax/Declarations/ModuleFile.swift
+++ b/Sources/Syntax/Declarations/ModuleFile.swift
@@ -7,6 +7,15 @@ import Parsing
 public struct ModuleFile<A: Annotation> {
   public var declarations: [SyntaxNode<Declaration<A>>]
   public let trailingTrivia: [Trivia]
+
+  public func addAnnotation<NewAnnotation: Annotation>(
+    _ transform: (Declaration<A>) throws -> Declaration<NewAnnotation>
+  ) rethrows -> ModuleFile<NewAnnotation> {
+    try .init(
+      declarations: declarations.map { try $0.map(transform) },
+      trailingTrivia: trailingTrivia
+    )
+  }
 }
 
 let moduleFileParser =

--- a/Sources/Syntax/Expressions/Closure.swift
+++ b/Sources/Syntax/Expressions/Closure.swift
@@ -37,13 +37,13 @@ public struct Closure<A: Annotation> {
 
   public func addAnnotation<NewAnnotation: Annotation>(
     parameter parameterTransform: (Expr<A>) throws -> Expr<NewAnnotation>,
-    body bodyTransform: (Body) throws -> Closure<NewAnnotation>.Body
+    body bodyTransform: (ExprBlock<A>) throws -> ExprBlock<NewAnnotation>
   ) rethrows -> Closure<NewAnnotation> {
     try .init(
       openBrace: openBrace,
       parameters: parameters.map { try $0.addAnnotation(parameterTransform) },
       inKeyword: inKeyword,
-      body: bodyTransform(body),
+      body: bodyTransform(exprBlock).elements,
       closeBrace: closeBrace
     )
   }

--- a/Sources/TypeChecker/Inference/TypeAnnotation.swift
+++ b/Sources/TypeChecker/Inference/TypeAnnotation.swift
@@ -21,7 +21,7 @@ extension Literal {
   }
 }
 
-typealias TypeAnnotation = Type
+public typealias TypeAnnotation = Type
 
 extension TypeAnnotation: Annotation {}
 
@@ -30,13 +30,28 @@ extension Expr where A == EmptyAnnotation {
     _ environment: ModuleEnvironment
   ) throws -> Expr<TypeAnnotation> {
     var system = ConstraintSystem(environment)
-    let annotatedExpr = try system.annotate(expr: self)
+    let annotated = try system.annotate(expr: self)
 
     let solver = Solver(
       substitution: [:],
       system: system
     )
-    return try annotatedExpr.apply(solver.solve())
+    return try annotated.apply(solver.solve())
+  }
+}
+
+extension FuncDecl where A == EmptyAnnotation {
+  func annotate(
+    _ environment: ModuleEnvironment
+  ) throws -> FuncDecl<TypeAnnotation> {
+    var system = ConstraintSystem(environment)
+    let annotated = try system.annotate(funcDecl: self)
+
+    let solver = Solver(
+      substitution: [:],
+      system: system
+    )
+    return try annotated.apply(solver.solve())
   }
 }
 

--- a/Tests/KaraTests/EvalTests.swift
+++ b/Tests/KaraTests/EvalTests.swift
@@ -135,4 +135,18 @@ final class EvalTests: XCTestCase {
       .closure(parameters: [], body: .literal("static"))
     )
   }
+
+  func testLeadingDot() {
+    assertEval(
+      """
+      {
+        struct Int32 { static let max: Int32 = 2147483647 }
+        func f(x: Int32, y: Int32) { x }
+
+        f(.max, 0)
+      }
+      """,
+      .closure(parameters: [], body: .literal(2_147_483_647))
+    )
+  }
 }

--- a/Tests/KaraTests/EvalTests.swift
+++ b/Tests/KaraTests/EvalTests.swift
@@ -135,18 +135,4 @@ final class EvalTests: XCTestCase {
       .closure(parameters: [], body: .literal("static"))
     )
   }
-
-  func testLeadingDot() {
-    assertEval(
-      """
-      {
-        struct Int32 { static let max: Int32 = 2147483647 }
-        func f(x: Int32, y: Int32) { x }
-
-        f(.max, 0)
-      }
-      """,
-      .closure(parameters: [], body: .literal(2_147_483_647))
-    )
-  }
 }


### PR DESCRIPTION
This would allow processing `leadingDot` expressions in `JSCodegen`, giving it access to the inferred type of such expressions.